### PR TITLE
make clib/bpkg friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,87 @@
-This is ctypes.sh, a foreign function interface for bash.
+# ctypes.sh
 
-ctypes.sh is a bash plugin that provides a foreign function interface directly
+This is `ctypes.sh`, a foreign function interface for bash.
+
+`ctypes.sh` is a bash plugin that provides a foreign function interface directly
 in your shell. In other words, it allows you to call routines in shared
 libraries from within bash.
 
 A (very) simple example will help illustrate:
 
-    $ dlcall $RTLD_NEXT puts "hello, world"
-    hello, world
+```bash
+$ dlcall $RTLD_DEFAULT puts "hello, world"
+hello, world
+```
 
-ctypes.sh can extend bash scripts to accomplish tasks that were previously
+`ctypes.sh` can extend bash scripts to accomplish tasks that were previously
 impossible, or would require external helpers to be written.
 
-Here is what people have been saying about ctypes.sh:
+## prerequisites
+
+`ctypes.sh` is dependent on the following libraries and programs:
+
+* libffi-dev
+* binutils-dev
+* libdl
+* make
+
+## install
+
+`ctypes.sh` can be installed in several ways. You can use the
+[clib](https://github.com/clibs/clib) or
+[bpkg](https://github.com/bpkg/bpkg) package manager to install
+`ctypes.sh`.
+
+```bash
+$ clib install taviso/ctypes.sh
+```
+
+```bash
+$ bpkg install taviso/ctypes.sh
+```
+
+You can also build and install from source:
+
+```bash
+$ git clone https://github.com/taviso/ctypes.sh.git
+$ cd ctypes.sh
+$ make
+$ [sudo] make install
+```
+
+By default `ctypes.sh` is installed into `/usr/local/bin` and
+`/usr/local/lib`. You can overload the prefix path by defining the
+`PREFIX` environment variable before installing.
+
+```bash
+$ PREFIX=$HOME clib install taviso/ctypes.sh
+```
+
+or
+
+```bash
+$ PREFIX=$HOME bpkg nstall taviso/ctypes.sh
+```
+
+or
+
+```bash
+$ PREFIX=$HOME make install
+```
+
+## example
+
+```bash
+source $(which ctypes.sh)
+puts () {
+  dlcall $RTLD_DEFAULT puts "$@"
+  return $?
+}
+
+puts "hello, world!"
+```
+
+## Here is what people have been saying about ctypes.sh:
 
 * "that's disgusting"
 * "this has got to stop"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ctypes.sh",
+  "version": "0.0.1",
+  "repo": "taviso/ctypes.sh",
+  "description": "A foreign function interface for bash.",
+  "keywords": ["bash", "ffi", "ctypes"],
+  "global": true,
+  "install": "make install"
+}
+


### PR DESCRIPTION
This makes it so this awesome tool can be installed with [bpkg](https://github.com/bpkg/bpkg) or [clib](https://github.com/clibs/clib). I've also updated the README a bit to show how to install it.