### PR TITLE
Port ctypes.sh to FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 CFLAGS  = -std=gnu99 -fPIC -O0 -ggdb3 -Wall -Wextra -fvisibility=hidden
 CPPFLAGS= -Iinclude $(shell pkg-config --cflags libffi)
-LDLIBS  = $(shell pkg-config --libs libffi) -ldl
+UNAME_S = $(shell uname -s)
+LDLIBS  = $(shell pkg-config --libs libffi)
+ifneq ($(UNAME_S),FreeBSD)
+	LDLIBS += -ldl
+endif
 PREFIX	= /usr/local
 
 .PHONY: clean install

--- a/callback.c
+++ b/callback.c
@@ -24,11 +24,12 @@
 #include "types.h"
 #include "shell.h"
 
-static int execute_bash_trampoline(ffi_cif *cif, void *retval, void **args, char **proto)
+static void execute_bash_trampoline(ffi_cif *cif, void *retval, void **args, void *uarg)
 {
     SHELL_VAR *function;
     WORD_LIST *params;
     char *result;
+    char **proto = uarg;
 
     // Decode parameters
     // callback hello pointer pointer int int
@@ -36,7 +37,7 @@ static int execute_bash_trampoline(ffi_cif *cif, void *retval, void **args, char
     //
     if (!(function = find_function(*proto))) {
         fprintf(stderr, "error: unable to resolve function %s in thunk", *proto);
-        return -1;
+        return;
     }
 
     params = NULL;
@@ -60,7 +61,7 @@ static int execute_bash_trampoline(ffi_cif *cif, void *retval, void **args, char
     execute_shell_function(function, params);
 
     free(result);
-    return 0;
+    return;
 }
 
 static int generate_native_callback(WORD_LIST *list)

--- a/types.c
+++ b/types.c
@@ -21,6 +21,20 @@
 #include "types.h"
 #include "util.h"
 
+#ifndef __GLIBC__
+#include <sys/param.h>
+#define strndupa(s, n) ({                               \
+    const char *__s = (s);                              \
+    size_t __n = (n);                                   \
+    char *__r;                                          \
+    __n = MIN(__n, strlen(__s));                        \
+    __r = alloca(__n + 1);                              \
+    memcpy(__r, __s, __n);                              \
+    __r[__n] = '\0';                                    \
+    __r;                                                \
+})
+#endif
+
 bool decode_primitive_type(const char *parameter, void **value, ffi_type **type)
 {
     const char *prefix;
@@ -97,7 +111,7 @@ bool decode_type_prefix(const char *prefix, const char *value, ffi_type **type, 
         { "pointer", &ffi_type_pointer, "%p", "pointer:%p" },
         { "string", &ffi_type_pointer, "%ms", "string:%s" },
         { "void", &ffi_type_void, "", "" },
-        { NULL },
+        { },
     };
 
     for (int i = 0; types[i].prefix; i++) {


### PR DESCRIPTION
Fix a number of platform agnostic Clang warnings:

- ffi_prep_closure_loc()'s callback returns void; fix
  execute_bash_trampoline to match
- Fix a few instances of the wrong pointer type being passed to
  check_parse_ulong()
- Pull decode_element closures (GCC extension) out of
  pack_prefixed_array(), unpack_prefixed_array()

Fix a number of Glibcisms and Linuxisms:

- FreeBSD doesn't need -ldl
- RTLD_DEEPBIND is a Linuxism
- Implement vaguely portable strndupa() and mempcpy