### PR TITLE
Darwin fixes and untested Windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,38 @@
-CFLAGS  = -std=gnu99 -fPIC -O0 -ggdb3 -Wall -Wextra -fvisibility=hidden
-CPPFLAGS= -Iinclude $(shell pkg-config --cflags libffi)
-UNAME   = $(shell uname -s)
-LDLIBS  = $(shell pkg-config --libs libffi)
-PREFIX	= /usr/local
+CFLAGS  := -std=gnu99 -fPIC -O0 -ggdb3 -Wall -Wextra -fvisibility=hidden
+CPPFLAGS:= -Iinclude $(shell pkg-config --cflags libffi)
+LDLIBS  := $(shell pkg-config --libs libffi)
+PREFIX	:= /usr/local
+UNAME    = $(shell uname -s)
+SOEXT   := so
 
 ifeq ($(UNAME), Linux)
 	LDLIBS += -ldl
+else ifeq ($(UNAME), Darwin)
+	LDFLAGS += -bundle -undefined dynamic_lookup
+	SOEXT = bundle
+else
+	LDFLAGS += -shared
+  ifeq ($(shell uname -o), Msys)
+	SOEXT = dll
+  else ifeq ($(shell uname -o), Cygwin)
+	SOEXT = dll
+  endif
+endif
+ifeq ($(SOEXT), dll)
+# TODO: Windows needs to link to the bash .dll or .exe
+	LDLIBS  += bash.dll
 endif
 
 .PHONY: clean install
 
-all: ctypes.so ctypes.sh
+all: ctypes.$(SOEXT) ctypes.sh
 
-ctypes.so: ctypes.o util.o callback.o types.o unpack.o
-	$(CC) $(LDFLAGS) $(CFLAGS) -shared -o $@ $^ $(LDLIBS)
+ctypes.$(SOEXT): ctypes.o util.o callback.o types.o unpack.o
+	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $^ $(LDLIBS)
 
 clean:
-	rm -f ctypes.so *.o
+	rm -f ctypes.$(SOEXT) *.o
 
-install: ctypes.so ctypes.sh
+install: ctypes.$(SOEXT) ctypes.sh
 	install ctypes.sh $(PREFIX)/bin
-	install ctypes.so $(PREFIX)/lib
+	install ctypes.$(SOEXT) $(PREFIX)/lib

--- a/callback.c
+++ b/callback.c
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include <assert.h>
 #include <stdbool.h>
-#include <link.h>
 #include <ffi.h>
 #include <inttypes.h>
 

--- a/types.c
+++ b/types.c
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include <assert.h>
 #include <stdbool.h>
-#include <link.h>
 #include <ffi.h>
 #include <inttypes.h>
 

--- a/unpack.c
+++ b/unpack.c
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include <assert.h>
 #include <stdbool.h>
-#include <link.h>
 #include <ffi.h>
 #include <inttypes.h>
 
@@ -23,7 +22,7 @@
 #include "types.h"
 #include "shell.h"
 
-#ifndef __GLIBC__
+#if !defined(__GLIBC__) && !defined(__NEWLIB__)
 static inline void *mempcpy(void *dest, const void *src, size_t n)
 {
     memcpy(dest, src, n);
@@ -133,7 +132,12 @@ int unpack_decode_element(ARRAY_ELEMENT *element, void *user)
 
     // Truncate it if there's already a value, e.g.
     // a=(int:0 int:0) is accceptable to initialize a buffer.
+#ifdef __GLIBC__
     *strchrnul(element->value, ':') = '\0';
+#else
+    if ((format = strchr(element->value, ':')))
+        *format = '\0';
+#endif
 
     if (decode_type_prefix(element->value,
                            NULL,


### PR DESCRIPTION
Based on cemeyer's better FreeBSD patches.
Remove link.h which is currently not used.
Workaround strchrnul
Add Darwin and Windows logic to Makefile
Cygwin (ie newlib) has mempcpy defined