### PR TITLE
Support for the DESTDIR option during make install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -32,6 +32,6 @@ distclean: clean
 	rm -rf config.sub config.guess
 
 install: ctypes.$(SOEXT) ctypes.sh
-	install -d @bindir@ @libdir@
-	install ctypes.sh @bindir@
-	install ctypes.$(SOEXT) @libdir@
+	install -d ${DESTDIR}@bindir@ ${DESTDIR}@libdir@
+	install ctypes.sh ${DESTDIR}@bindir@
+	install ctypes.$(SOEXT) ${DESTDIR}@libdir@


### PR DESCRIPTION
Some workflows (i.e. package creation) don't require root and instead install to a temporary directory, building the package from there:

     ./configure --prefix=/usr
     make
     mkdir -p /tmp/ctypes
     make install DESTDIR=/tmp/ctypes