### PR TITLE
docs: fix simple typo, abtract -> abstract

### DIFF
--- a/src/struct/dwarf_loader.c
+++ b/src/struct/dwarf_loader.c
@@ -1997,7 +1997,7 @@ static int tag__recode_dwarf_type(struct tag *tag, struct cu *cu)
 	case DW_TAG_namespace:
 		return namespace__recode_dwarf_types(tag, cu);
 	/* Damn, DW_TAG_inlined_subroutine is an special case
-           as dwarf_tag->id is in fact an abtract origin, i.e. must be
+           as dwarf_tag->id is in fact an abstract origin, i.e. must be
 	   looked up in the tags_table, not in the types_table.
 	   The others also point to routines, so are in tags_table */
 	case DW_TAG_inlined_subroutine:


### PR DESCRIPTION
There is a small typo in src/struct/dwarf_loader.c.

Should read `abstract` rather than `abtract`.

