### PR TITLE
Migrate the GTK example to GTK 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ double:1.000000
 impossible, or would require external helpers to be written.
 
 `ctypes.sh` makes it possible to use
-[GTK+](https://github.com/taviso/ctypes.sh/blob/master/test/gtk.sh) natively in
+[GTK](https://github.com/taviso/ctypes.sh/blob/master/test/gtk.sh) natively in
 your shell scripts, or write a [high-performance http daemon](https://github.com/cemeyer/httpd.sh).
 
 See more examples [here](https://github.com/taviso/ctypes.sh/tree/master/test)

--- a/test/gtk.sh
+++ b/test/gtk.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-# This is a port of the GTK+3 Hello World to bash.
+# This is a port of the GTK 4 Hello World to bash.
 #
-# https://developer.gnome.org/gtk3/stable/gtk-getting-started.html
+# https://docs.gtk.org/gtk4/getting_started.html
 source ctypes.sh
 
-# declare some numeric constants used by GTK+
+# declare some numeric constants used by GTK
 declare -ri GTK_ORIENTATION_HORIZONTAL=0
+declare -ri GTK_ALIGN_CENTER=3
 declare -ri G_APPLICATION_FLAGS_NONE=0
 declare -ri G_CONNECT_AFTER=$((1 << 0))
 declare -ri G_CONNECT_SWAPPED=$((1 << 1))
@@ -26,21 +27,23 @@ function activate ()
     local button
     local button_box
 
-    dlsym -n gtk_widget_destroy gtk_widget_destroy
+    dlsym -n gtk_window_destroy gtk_window_destroy
 
     dlcall -n window -r pointer gtk_application_window_new $app
     dlcall gtk_window_set_title $window "Window"
     dlcall gtk_window_set_default_size $window 200 200
 
-    dlcall -n button_box -r pointer gtk_button_box_new $GTK_ORIENTATION_HORIZONTAL
-    dlcall gtk_container_add $window $button_box
+    dlcall -n button_box -r pointer gtk_box_new $GTK_ORIENTATION_HORIZONTAL 0
+    dlcall gtk_widget_set_halign $button_box $GTK_ALIGN_CENTER
+    dlcall gtk_widget_set_valign $button_box $GTK_ALIGN_CENTER
+    dlcall gtk_window_set_child $window $button_box
 
     dlcall -n button -r pointer gtk_button_new_with_label "Hello World"
     dlcall g_signal_connect_data $button "clicked" $print_hello $NULL $NULL 0
-    dlcall g_signal_connect_data $button "clicked" $gtk_widget_destroy $window $NULL $G_CONNECT_SWAPPED
-    dlcall gtk_container_add $button_box $button
+    dlcall g_signal_connect_data $button "clicked" $gtk_window_destroy $window $NULL $G_CONNECT_SWAPPED
+    dlcall gtk_box_append $button_box $button
 
-    dlcall gtk_widget_show_all $window
+    dlcall gtk_widget_show $window
 }
 
 declare app     # GtkApplication *app
@@ -53,8 +56,8 @@ callback -n activate activate void pointer pointer
 # Prevent threading issues.
 taskset -p 1 $$ &> /dev/null
 
-# Make libgtk-3 symbols available
-dlopen libgtk-3.so.0
+# Make libgtk-4 symbols available
+dlopen libgtk-4.so.1
 
 dlcall -n app -r pointer gtk_application_new "org.gtk.example" $G_APPLICATION_FLAGS_NONE
 dlcall -r ulong g_signal_connect_data $app "activate" $activate $NULL $NULL 0


### PR DESCRIPTION
There were minimal changes to this example, the main difference is that `halign` and `valign` now default to `GTK_ALIGN_FILL` instead of `GTK_ALIGN_CENTER`.